### PR TITLE
Don't hard code library path on Linux

### DIFF
--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -3,7 +3,7 @@ let lib: Deno.DynamicLibrary<typeof s>;
 
 switch(Deno.build.os) {
   case 'linux':
-    lib = Deno.dlopen('/lib/x86_64-linux-gnu/libncursesw.so.6', s);
+    lib = Deno.dlopen('libncursesw.so.6', s);
     break;
   case 'darwin':
     lib = Deno.dlopen('libncurses.dylib', s);


### PR DESCRIPTION
The so far hard coded path to the ncurses library is not correct for me on Linux. Using just the library name works fine for me and is probably more portable?